### PR TITLE
Add UTF-16le support (fix SpeedyPaths manifest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ This is a script to assist with packaging mods from Thunderstore.io into a zip f
 
 ## Requirements
 
-`pip3 install packaging`
+`pip3 install packaging python-magic`
 
-Python3 and the packaging pip.  Tested on Ubuntu 22.04.
+Python3 and the [packaging, python-magic] packages.  Tested on Ubuntu 22.04.
 
 ## Configuration
 


### PR DESCRIPTION
Some mod developers save their manifests as UTF-16le (the default for the macOS notepad app iirc), which cannot be read in via `utf-8-sig` decoding. This change uses the `magic` lib to autodetect encoding and proceed appropriately.